### PR TITLE
Editorial: voeg verwijzingen naar beheermodel toe

### DIFF
--- a/Abstract.md
+++ b/Abstract.md
@@ -1,6 +1,8 @@
 
 ## Abstract
 <!-- ### [Abstract](#rfc.abstract) -->
-The OAuth 2.0 protocol framework defines a mechanism to allow a resource owner to delegate access to a protected resource for a client application.  
+The OAuth 2.0 protocol framework defines a mechanism to allow a resource owner to delegate access to a protected resource for a client application.
 
 This specification profiles the OAuth 2.0 protocol framework to increase baseline security, provide greater interoperability, and structure deployments in a manner specifically applicable, but not limited to consumer-to-government deployments in the Netherlands.
+
+[The Governance of this standard](https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/) is described by the API-Standaarden beheermodel in a [separate repository](https://github.com/Logius-standaarden/API-Standaarden-Beheermodel/) and published by Logius.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Bij het Kennisplatform APIs is onlangs een sessie geweest om kennis te delen ove
   - https://publicatie.centrumvoorstandaarden.nl/api/oauth/
 - Bekijk hier **de laatste werkversie** van de standaard:
   - https://Logius-standaarden.github.io/OAuth-NL-profiel
+- Bekijk hier **het beheermodel** van deze standaard:
+  - https://gitdocumentatie.logius.nl/publicatie/api/beheermodel/
 
 ## Meedoen
 


### PR DESCRIPTION
Eerder was het beheermodel een oAuth specifiek
beheermodel [1] die niet expliciet gelinkt was in
deze standaard. Tevens updaten wij nu
standaard-specifieke beheermodelen naar het
generieke API-standaard beheermodel om duplicatie
te voorkomen.

[1]: https://github.com/Logius-standaarden/OAuth-Beheermodel